### PR TITLE
Update end dates and censor COVID patients in comparator groups

### DIFF
--- a/analysis/global.do
+++ b/analysis/global.do
@@ -9,6 +9,4 @@ di "$tabfigdir"
 * Create directories required 
 capture mkdir "$tabfigdir"
 
-global dataEndDate td(01oct2020)
-
 adopath + $projectdir/analysis/ado

--- a/analysis/study_definition_covid_2020.py
+++ b/analysis/study_definition_covid_2020.py
@@ -67,6 +67,9 @@ study = StudyDefinition(
     patient_index_date=patients.minimum_of(
         "sgss_positive", "primary_care_covid", "hospital_covid"
     ),
+    covid_diagnosis_date=patients.minimum_of(
+        "sgss_positive", "primary_care_covid", "hospital_covid"
+    ),
     covid_classification=patients.categorised_as(
         {
             "0": "DEFAULT",

--- a/analysis/study_definition_general_2019.py
+++ b/analysis/study_definition_general_2019.py
@@ -63,6 +63,9 @@ study = StudyDefinition(
         date_format="YYYY-MM-DD",
         return_expectations={"date": {"earliest": "index_date"}},
     ),
+    covid_diagnosis_date=patients.minimum_of(
+        "sgss_positive", "primary_care_covid", "hospital_covid"
+    ),
     **demographic_variables,
     **clinical_variables,
     **outcome_variables

--- a/analysis/study_definition_general_2020.py
+++ b/analysis/study_definition_general_2020.py
@@ -63,6 +63,9 @@ study = StudyDefinition(
         date_format="YYYY-MM-DD",
         return_expectations={"date": {"earliest": "index_date"}},
     ),
+    covid_diagnosis_date=patients.minimum_of(
+        "sgss_positive", "primary_care_covid", "hospital_covid"
+    ),
     **demographic_variables,
     **clinical_variables,
     **outcome_variables


### PR DESCRIPTION
Updated end dates – turns out the global end date variable wasn't being used, but local end dates had been set to 01/11/{year}.

Also censored patients with COVID in the comparator groups (and added COVID diagnosis dates in the study definitions where missing).