### PR TITLE
Drop if sick note before hospitalisation

### DIFF
--- a/analysis/000_cr_define_covariates_simple_rates.do
+++ b/analysis/000_cr_define_covariates_simple_rates.do
@@ -244,6 +244,8 @@ foreach out in sick_note {
 
 }
 
+drop if sick_note_end_date <= indexdate
+
 postclose `outcomeDist'
 										
 order patient_id indexdate

--- a/analysis/100_cr_simple_rates_hosp.do
+++ b/analysis/100_cr_simple_rates_hosp.do
@@ -31,6 +31,9 @@ drop if hosp_expo_date == .
 drop indexdate
 gen indexdate = hosp_expo_date
 
+* Drop if sick note between initial diagnosis and hospitalisation
+drop if sick_note_end_date <= indexdate
+
 tempname measures
 																	 
 	postfile `measures' str16(group) str25(outcome) str12(time) ///


### PR DESCRIPTION
Drop people whose first COVID record was a test/GP record but had a sick note prior to hospitalisation (for hospital analyses only)